### PR TITLE
Resolve linter warnings

### DIFF
--- a/tools/dev-server/index.js
+++ b/tools/dev-server/index.js
@@ -65,11 +65,13 @@ new WebpackDevServer(webpack(webpackConfig), {
     // Wait to start listening until ExpressOIDC is ready.
     oidc.on('ready', () => {
       app.listen(config.server.port, () => {
+        /* eslint-disable no-console */
         console.log(`Express server started on http://localhost:${config.server.port}`);
       });
     });
 
     oidc.on('error', (err) => {
+      /* eslint-disable no-console */
       console.log('Unable to configure ExpressOIDC', err);
     });
   },


### PR DESCRIPTION
Although in travis and locally these are just warnings, in our internal CI these seem to be exiting the process with an error